### PR TITLE
(´･ω･`) Reordering keys to fix removeSongAtIndex(0)

### DIFF
--- a/server/PriorityQ.js
+++ b/server/PriorityQ.js
@@ -6,18 +6,9 @@ Basic structure is a Map<String, Array>
 */
 export default class PriorityQ {
   qMap = new Map()
-  head = 0
   length = 0 // length of resultant song queue
 
   constructor() { }
-
-  updateHead() {
-    if (this.head >= this.qMap.size - 1) {
-      this.head = 0
-    } else {
-      this.head++
-    }
-  }
 
   push(song) {
     const username = song.username
@@ -33,22 +24,14 @@ export default class PriorityQ {
 
   shift() {
     if (this.length > 0) {
-      const keysArray = Array.from(this.qMap.keys());
-      const username = keysArray[this.head];
-      const userSongList = this.qMap.get(username)
+      const [ username, userSongList ] = this.qMap.entries().next().value
       const nextSong = userSongList.shift()
-      
+
       if (userSongList.length > 0) {
-        this.updateHead()
+        // reorder map keys
+        this.qMap.delete(username)
+        this.qMap.set(username, userSongList)
       } else {
-        const toDeleteIndex =  keysArray.indexOf(username);
-        // if userSongList == 0 and user is last element of users
-        // we can just set head to 0 directly
-        // otherwise, don't update head, since we remove the user key
-        // and next user is at current head
-        if (toDeleteIndex == this.qMap.size - 1) {
-          this.head = 0
-        }
         this.qMap.delete(username)
       }
       this.length--
@@ -70,8 +53,8 @@ export default class PriorityQ {
           if (this.qMap.get(username)[depth]) {
             if (index == n) {
               return ({
-                username, 
-                depth 
+                username,
+                depth
               });
             }
             index++
@@ -85,18 +68,18 @@ export default class PriorityQ {
 
   getSongAtIndex(i) {
     const { username, depth } = this.traverse(i)
-    
     return this.qMap.get(username)[depth];
   }
 
   removeSongAtIndex(i) {
-    const { username, depth } = this.traverse(i)
-    this.qMap.get(username).splice(depth, 1)
-    this.length--
-    // if we're removing the current song, then don't repeat turn
-    // go to next guy
+    // if removing 0, we still want to shift to reorder map
+    // i.e. only skip person's turn if we remove current song
     if (i == 0) {
-      this.updateHead()
+      this.shift()
+    } else {
+      const { username, depth } = this.traverse(i)
+      this.qMap.get(username).splice(depth, 1)
+      this.length--
     }
   }
 

--- a/server/PriorityQ.test.js
+++ b/server/PriorityQ.test.js
@@ -4,17 +4,17 @@ import Song from './Song.js'
 // aaa: song1, song3
 // bbb: song2, song4
 var prioQ = new PriorityQ()
-const song1 = new Song('aaa', '111', null, 10)
+const songA1 = new Song('aaa', '111', null, 10)
 const song1Copy = new Song('aaa', '111', null, 10)
-const song2 = new Song('bbb', "222", null, 20)
-const song3 = new Song('aaa', "333", null, 30)
-const song4 = new Song('bbb', "444", null, 40)
-const songs = [song1, song2, song3, song4]
+const songB1 = new Song('bbb', "222", null, 20)
+const songA2 = new Song('aaa', "333", null, 30)
+const songB2 = new Song('bbb', "444", null, 40)
+const songs = [songA1, songB1, songA2, songB2]
 
 // ghetto manual tests with no testing framework xd
 // run using node PriorityQ.test.js and check all cases return true
 
-console.log(song1.equals(song1Copy))
+console.log(songA1.equals(song1Copy))
 
 setup()
 pushTest()
@@ -28,21 +28,24 @@ getSongAtIndexTest()
 setup()
 removeSongAtIndexTest()
 
+setup()
+removeFirstSongTest()
+
 // methods
 function setup() {
     prioQ = new PriorityQ()
-    prioQ.push(song1)
-    prioQ.push(song2)
-    prioQ.push(song3)
-    prioQ.push(song4)
+    prioQ.push(songA1)
+    prioQ.push(songB1)
+    prioQ.push(songA2)
+    prioQ.push(songB2)
 }
 
 function pushTest() {
     let newPrioQ = new PriorityQ()
     console.log("Push Test...")
-    newPrioQ.push(song1)
+    newPrioQ.push(songA1)
     console.log(`pushTest case 1a: ${newPrioQ.length == 1}`)
-    console.log(`pushTest case 1b: ${newPrioQ.qMap.get(song1.username)[0] == song1}`)
+    console.log(`pushTest case 1b: ${newPrioQ.qMap.get(songA1.username)[0] == songA1}`)
 }
 
 function shiftTest() {
@@ -50,22 +53,21 @@ function shiftTest() {
 
 
     console.log("Checking sequential shift() against song constants")
-    console.log(`shiftTest case 1a: ${song1 == prioQ.shift()}`)
+    console.log(`shiftTest case 1a: ${songA1 == prioQ.shift()}`)
     console.log(`shiftTest case 1c: ${prioQ.length == 3}`)
 
-    console.log(`shiftTest case 2a: ${song2 == prioQ.shift()}`)
+    console.log(`shiftTest case 2a: ${songB1 == prioQ.shift()}`)
     console.log(`shiftTest case 2c: ${prioQ.length == 2}`)
 
-    console.log(`shiftTest case 3a: ${song3 == prioQ.shift()}`)
+    console.log(`shiftTest case 3a: ${songA2 == prioQ.shift()}`)
     console.log(`shiftTest case 3d: ${prioQ.length == 1}`)
 
-    console.log(`shiftTest case 4a: ${song4 == prioQ.shift()}`)
+    console.log(`shiftTest case 4a: ${songB2 == prioQ.shift()}`)
     console.log(`shiftTest case 4c: ${prioQ.length == 0}`)
 
     // check if fields of prioQ are reset even after an empty shfit
     prioQ.shift()
     console.log(`shiftTest case 5a: ${prioQ.length == 0}`)
-    console.log(`shiftTest case 5c: ${prioQ.head == 0}`)
     console.log(`shiftTest case 5d: ${prioQ.qMap.size == 0}`)
 }
 
@@ -80,10 +82,31 @@ function getSongAtIndexTest() {
 
 function removeSongAtIndexTest() {
     prioQ.removeSongAtIndex(0)
-    console.log(`removeItemAtIndexTest case 1: ${prioQ.shift() == song2}`)
+    console.log(`removeItemAtIndexTest case 1: ${prioQ.shift() == songB1}`)
     setup()
     prioQ.removeSongAtIndex(1)
     prioQ.shift()
-    console.log(`removeItemAtIndexTest case 2: ${prioQ.shift() == song4}`)
+    console.log(`removeItemAtIndexTest case 2: ${prioQ.shift() == songB2}`)
 
+}
+
+function removeFirstSongTest() {
+    const songC1 = new Song('ccc', '111', null, 10)
+    const songC2 = new Song('ccc', '222', null, 20)
+    prioQ.push(songC1)
+    prioQ.push(songC2)
+
+    prioQ.removeSongAtIndex(0)
+    console.log(`removeFirstSongTest case 1a: ${prioQ.length == 5}`)
+    console.log(`removeFirstSongTest case 1b: ${prioQ.shift() == songB1}`)
+    console.log(`removeFirstSongTest case 1c: ${prioQ.getSongAtIndex(prioQ.length-1) == songC2}`)
+
+    prioQ.removeSongAtIndex(0)
+    console.log(`removeFirstSongTest case 2a: ${prioQ.length == 3}`)
+    console.log(`removeFirstSongTest case 2b: ${prioQ.shift() == songA2}`)
+    console.log(`removeFirstSongTest case 2c: ${prioQ.getSongAtIndex(prioQ.length-1) == songC2}`)
+
+    prioQ.removeSongAtIndex(0)
+    console.log(`removeFirstSongTest case 3a: ${prioQ.length == 1}`)
+    console.log(`removeFirstSongTest case 3b: ${prioQ.shift() == songC2}`)
 }


### PR DESCRIPTION
Done by reordering the map's keys upon shift() instead of keeping track of the index via head. This means current song/next song in the prioQ is now always the first element of the first key.

Fixes #9 